### PR TITLE
Invoice作成のレスポンスが要件と異なっていたため修正

### DIFF
--- a/cmd/invoiceapi/internal/adapter/http/invoice.go
+++ b/cmd/invoiceapi/internal/adapter/http/invoice.go
@@ -40,7 +40,10 @@ func (h *invoiceHandler) CreateInvoice(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.WriteHeader(http.StatusCreated)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(invoice)
+	// TODO: エラーハンドリング
 }
 
 func (h *invoiceHandler) ListInvoices(w http.ResponseWriter, r *http.Request) {

--- a/cmd/invoiceapi/internal/domain/invoice.go
+++ b/cmd/invoiceapi/internal/domain/invoice.go
@@ -15,20 +15,20 @@ const (
 )
 
 type Invoice struct {
-	ID                string
-	CompanyID         string
-	BusinessPartnerID string
-	IssueDate         timex.Date
-	PaymentAmount     float64
-	FeeRate           float64
-	FeeAmount         float64
-	TaxRate           float64
-	TaxAmount         float64
-	TotalAmount       float64
-	DueDate           timex.Date
-	Status            string
-	CreatedAt         time.Time
-	UpdatedAt         time.Time
+	ID                string     `json:"id"`
+	CompanyID         string     `json:"company_id"`
+	BusinessPartnerID string     `json:"business_partner_id"`
+	IssueDate         timex.Date `json:"issue_date"`
+	PaymentAmount     float64    `json:"payment_amount"`
+	FeeRate           float64    `json:"fee_rate"`
+	FeeAmount         float64    `json:"fee_amount"`
+	TaxRate           float64    `json:"tax_rate"`
+	TaxAmount         float64    `json:"tax_amount"`
+	TotalAmount       float64    `json:"total_amount"`
+	DueDate           timex.Date `json:"due_date"`
+	Status            string     `json:"status"`
+	CreatedAt         time.Time  `json:"created_at"`
+	UpdatedAt         time.Time  `json:"updated_at"`
 }
 
 func NewInvoice(

--- a/internal/timex/date.go
+++ b/internal/timex/date.go
@@ -37,6 +37,10 @@ func (d *Date) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+func (d *Date) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.String())
+}
+
 func (d Date) String() string {
 	return d.t.Format(time.DateOnly)
 }


### PR DESCRIPTION
以下のようにstatus200OKを返しつつ、作成したObjectを返すようにした

```json
HTTP/1.1 200 OK
Content-Type: application/json
Date: Sun, 16 Feb 2025 04:20:58 GMT
Content-Length: 402
Connection: close

{
  "id": "01JM6FSW0JVX1W2DZ3EVBAW0HN",
  "company_id": "01JM6BKQNM5RNPG3WDCX4YHJT2",
  "business_partner_id": "01JM6BKQNU3B8ANY4MN5S7TUZ3",
  "issue_date": "2025-01-01",
  "payment_amount": 10000,
  "fee_rate": 0.04,
  "fee_amount": 400,
  "tax_rate": 0.1,
  "tax_amount": 40,
  "total_amount": 10440,
  "due_date": "2025-01-04",
  "status": "unprocessed",
  "created_at": "2025-02-16T04:20:58.003097074Z",
  "updated_at": "2025-02-16T04:20:58.003097324Z"
}
```